### PR TITLE
Optimize I/O Operations

### DIFF
--- a/src/kaidoMC/RegionProtect/Provider/VectorAdjust.php
+++ b/src/kaidoMC/RegionProtect/Provider/VectorAdjust.php
@@ -51,7 +51,7 @@ final class VectorAdjust {
 	 * @return array
 	 */
 	public function getLocations(): array {
-		return array_keys($this->locations);
+		return $this->locations;
 	}
 
 	/**

--- a/src/kaidoMC/RegionProtect/RegionProtect.php
+++ b/src/kaidoMC/RegionProtect/RegionProtect.php
@@ -93,13 +93,12 @@ class RegionProtect extends PluginBase {
 					break;
 				case "list":
 					$sender->sendMessage(TextFormat::YELLOW . "Total Regions in the world: (" . count($this->getVectorAdjust()->getLocations()) . ")");
-					foreach ($this->getVectorAdjust()->getLocations() as $file) {
-						$config = $this->getVectorAdjust()->getLocation(explode(".", $file)[0]);
+					foreach ($this->getVectorAdjust()->getLocations() as $name => $config) {
 						if ($config != null) {
 							if ($config->get("World") != $sender->getWorld()->getDisplayName()) {
 								continue;
 							}
-							$sender->sendMessage(TextFormat::GREEN . explode(".", $file)[0] . ": " . TextFormat::DARK_GRAY . $config->get("FirstVector")["X"] . " " . $config->get("FirstVector")["Y"] . " " . $config->get("FirstVector")["Z"]);
+							$sender->sendMessage(TextFormat::GREEN . $name . ": " . TextFormat::DARK_GRAY . $config->get("FirstVector")["X"] . " " . $config->get("FirstVector")["Y"] . " " . $config->get("FirstVector")["Z"]);
 						}
 					}
 					break;


### PR DESCRIPTION
This pull request optimize the Input/Output (I/O) operations. This pull request remove unnecessary I/O methods to enhance server performance especially during `PlayerMoveEvent` `PlayerInteractEvent` events, because they called alot.

### Examples of I/O operations
- [Constructing a new Config](https://github.com/pmmp/PocketMine-MP/blob/stable/src/utils/Config.php#L164)
- `\scandir()`
- `\file_get_contents()`

Note this PR remove all the I/O methods except when [creating a new region](https://github.com/Aboshxm2/RegionProtect/blob/I/O-Methods/src/kaidoMC/RegionProtect/Provider/VectorAdjust.php#L79)  or [deleting an existing reqion](https://github.com/Aboshxm2/RegionProtect/blob/I/O-Methods/src/kaidoMC/RegionProtect/Provider/VectorAdjust.php#L119), because they won't get called as much as the others.